### PR TITLE
Support fat gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /*.vimsession
+/vendor/local/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/czmq"]
 	path = vendor/czmq
 	url = https://github.com/zeromq/czmq.git
+[submodule "vendor/libzmq"]
+	path = vendor/libzmq
+	url = https://github.com/zeromq/libzmq.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y cmake mingw-w64 sudo
+
+CMD bash

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,74 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+
+windows_architectures = [
+  :x86,
+  :x64,
+]
+
+namespace :build do
+  namespace :windows do
+    windows_architectures.each do |architecture|
+      desc "Build gem for Windows #{architecture}"
+      task architecture => "pkg" do
+        sh("docker", "build",
+           "--tag", "czmq-ffi-gen-builder",
+           "--rm",
+           ".")
+        build_user_name = "build"
+        build_commands = [
+          "groupadd --gid #{Process.gid} #{build_user_name}",
+          "useradd --uid #{Process.uid} --gid #{Process.gid} #{build_user_name}",
+          "sudo -u #{build_user_name} /czmq-ffi-gen/build.sh #{architecture}",
+        ]
+        sh("docker", "run",
+           "--rm",
+           "--interactive",
+           "--tty",
+           "--volume", "#{Dir.pwd}:/czmq-ffi-gen",
+           "czmq-ffi-gen-builder",
+           "/bin/bash",
+           "-c",
+           build_commands.join(" && "))
+
+        spec = Bundler::GemHelper.gemspec.dup
+        spec.platform = "#{architecture}-mingw32"
+        spec.files += Dir.glob("vendor/local/**/*")
+        package = Gem::Package.new(File.join("pkg", spec.file_name))
+        package.spec = spec
+        package.build
+      end
+    end
+  end
+
+  windows_architectures.each do |architecture|
+    task :windows => "build:windows:#{architecture}"
+  end
+end
+
+namespace :release do
+  namespace :windows do
+    namespace :rubygem_push do
+      windows_architectures.each do |architecture|
+        task architecture => "build:windows:#{architecture}" do
+          helper = Bundler::GemHelper.instance
+          if helper.__send__(:gem_push?)
+            spec = helper.gemspec.dup
+            spec.platform = "#{architecture}-mingw32"
+            helper.__send__(:rubygem_push, "pkg/#{spec.file_name}")
+          end
+        end
+      end
+    end
+  end
+end
+
+windows_architectures.each do |architecture|
+  task :release => "release:windows:rubygem_push:#{architecture}"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace :build do
         build_commands = [
           "groupadd --gid #{Process.gid} #{build_user_name}",
           "useradd --uid #{Process.uid} --gid #{Process.gid} #{build_user_name}",
-          "sudo -u #{build_user_name} /czmq-ffi-gen/build.sh #{architecture}",
+          "sudo -u #{build_user_name} /czmq-ffi-gen/windows/build.sh #{architecture}",
         ]
         sh("docker", "run",
            "--rm",

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+# set -u
+# set -x
+
+ARCHITECTURE=$1
+
+BASE_DIR=$(cd $(dirname $0); pwd)
+cd ${BASE_DIR}
+
+PREFIX=${BASE_DIR}/vendor/local
+export PKG_CONFIG_LIBDIR=${PREFIX}/lib/pkgconfig
+
+if [ "${ARCHITECTURE}" = "x64" ]; then
+  COMPILER_PREFIX=x86_64-w64-mingw32
+else
+  COMPILER_PREFIX=i686-w64-mingw32
+fi
+
+rm -rf ${PREFIX}
+
+libzmq_build_dir=vendor/libzmq/build
+rm -rf ${libzmq_build_dir}
+mkdir -p ${libzmq_build_dir}
+cd ${libzmq_build_dir}
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  -DCMAKE_SYSTEM_NAME=Windows \
+  -DCMAKE_SYSTEM_PROCESSOR=${ARCHITECTURE} \
+  -DCMAKE_C_COMPILER=${COMPILER_PREFIX}-gcc \
+  -DCMAKE_CXX_COMPILER=${COMPILER_PREFIX}-g++ \
+  -DCMAKE_RC_COMPILER=${COMPILER_PREFIX}-windres \
+  -DZMQ_BUILD_TESTS=OFF \
+  -DHAVE_WS2_32=ON \
+  -DHAVE_RPCRT4=ON \
+  -DHAVE_IPHLAPI=ON
+make -j8
+make install
+cd -
+
+czmq_build_dir=vendor/czmq/build
+rm -rf ${czmq_build_dir}
+mkdir -p ${czmq_build_dir}
+cd ${czmq_build_dir}
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+  -DCMAKE_SYSTEM_NAME=Windows \
+  -DCMAKE_SYSTEM_PROCESSOR=${ARCHITECTURE} \
+  -DCMAKE_C_COMPILER=${COMPILER_PREFIX}-gcc \
+  -DCMAKE_CXX_COMPILER=${COMPILER_PREFIX}-g++ \
+  -DCMAKE_RC_COMPILER=${COMPILER_PREFIX}-windres
+make -j8
+make install
+cd -
+
+for gcc_dll in libstdc++-6.dll libgcc_s_sjlj-1.dll libgcc_s_seh-1.dll; do
+  absolute_gcc_dll=$(${COMPILER_PREFIX}-g++ -print-file-name=${gcc_dll})
+  if [ -f "${absolute_gcc_dll}" ]; then
+    cp "${absolute_gcc_dll}" vendor/local/bin
+  fi
+done

--- a/lib/czmq-ffi-gen.rb
+++ b/lib/czmq-ffi-gen.rb
@@ -1,9 +1,4 @@
-base_dir = File.expand_path(File.join(__dir__, ".."))
-vendor_bin_dir = File.join(base_dir, "vendor", "local", "bin")
-if File.exist?(vendor_bin_dir)
-  ENV["PATH"] = [vendor_bin_dir, ENV["PATH"]].join(File::PATH_SEPARATOR)
-end
-
+require_relative "czmq-ffi-gen/vendor"
 require_relative "czmq-ffi-gen/czmq/ffi"
 require_relative "czmq-ffi-gen/versions"
 require_relative "czmq-ffi-gen/errors"

--- a/lib/czmq-ffi-gen.rb
+++ b/lib/czmq-ffi-gen.rb
@@ -1,3 +1,9 @@
+base_dir = File.expand_path(File.join(__dir__, ".."))
+vendor_bin_dir = File.join(base_dir, "vendor", "local", "bin")
+if File.exist?(vendor_bin_dir)
+  ENV["PATH"] = [vendor_bin_dir, ENV["PATH"]].join(File::PATH_SEPARATOR)
+end
+
 require_relative "czmq-ffi-gen/czmq/ffi"
 require_relative "czmq-ffi-gen/versions"
 require_relative "czmq-ffi-gen/errors"

--- a/lib/czmq-ffi-gen/vendor.rb
+++ b/lib/czmq-ffi-gen/vendor.rb
@@ -1,0 +1,5 @@
+base_dir = File.expand_path(File.join(__dir__, "..", ".."))
+vendor_bin_dir = File.join(base_dir, "vendor", "local", "bin")
+if File.exist?(vendor_bin_dir)
+  ENV["PATH"] = [vendor_bin_dir, ENV["PATH"]].join(File::PATH_SEPARATOR)
+end

--- a/windows/build.sh
+++ b/windows/build.sh
@@ -6,7 +6,7 @@ set -e
 
 ARCHITECTURE=$1
 
-BASE_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(cd $(dirname $0)/..; pwd)
 cd ${BASE_DIR}
 
 PREFIX=${BASE_DIR}/vendor/local


### PR DESCRIPTION
Fat gem is a gem that includes built libraries. If czmq-ffi-gen gem
includes libzmq.dll and libczmq.dll, Windows users don't need to install
DevKit (= C compiler). It means that Windows users can use czmq-ffi-gen
gem by just running "gem install czmq-ffi-gen". Windows users don't
install libzmq.dll and libczmq.dll separately.

For example, ffi gem uses fat gem:
- https://rubygems.org/gems/ffi/versions/1.9.14-x86-mingw32
- https://rubygems.org/gems/ffi/versions/1.9.14-x64-mingw32

Developers need to build libzmq.dll and libczmq.dll to create a fat
gem. We can use Docker to set up cross compile environment for Windows.
We can use MinGW-w64 in the image.

This change adds the following Rake tasks:
- build:windows:x86: Builds a fat gem for Windows x86.
- build:windows:x64: Builds a fat gem for Windows x64.
- build:windows: Builds fat gems for Windows x86 and x64.
- release:windows:rubygem_push:x86: Pushes a fat gem for Windows x86.
- release:windows:rubygem_push:x64: Pushes a fat gem for Windows x64.

Normally, developers don't care about the tasks because "rake release"
runs release:windows:rubygem_push:x86 and
release:windows:rubygem_push:x64 automatically.

If it's difficult to prepare Docker on your environment, I can build
and push fat gem on my environment.

Bundled CZMQ update is required to fix cross compile build errors. We
need zermq/czmq#1515 and zermq/czmq#1516 to cross compile.
