### PR TITLE
Use Release build for bundled CZMQ for Windows

### DIFF
--- a/windows/build.sh
+++ b/windows/build.sh
@@ -44,6 +44,7 @@ rm -rf ${czmq_build_dir}
 mkdir -p ${czmq_build_dir}
 cd ${czmq_build_dir}
 cmake ${BASE_DIR}/vendor/czmq \
+  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_SYSTEM_NAME=Windows \
   -DCMAKE_SYSTEM_PROCESSOR=${ARCHITECTURE} \


### PR DESCRIPTION
To use Release build with "git clone"d source,
https://github.com/zeromq/czmq/commit/4acc4edfdb3f20adf5179bc2ce1c41c4e8ef87f3
change is required for CZMQ. So CZMQ is also updated.
