### PR TITLE
Add support for Ruby 2.4 on Windows (from oneclick/rubyinstaller2)

### DIFF
--- a/lib/czmq-ffi-gen/vendor.rb
+++ b/lib/czmq-ffi-gen/vendor.rb
@@ -1,5 +1,13 @@
 base_dir = File.expand_path(File.join(__dir__, "..", ".."))
 vendor_bin_dir = File.join(base_dir, "vendor", "local", "bin")
 if File.exist?(vendor_bin_dir)
-  ENV["PATH"] = [vendor_bin_dir, ENV["PATH"]].join(File::PATH_SEPARATOR)
+  # On Windows, RubyInstaller2 uses kernel32's SetDefaultDllDirectories
+  # and AddDllDirectory, which disables the lookup of DLLs in the PATH, see
+  # https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#dll-loading
+  begin
+    require 'ruby_installer'
+    RubyInstaller::Runtime.add_dll_directory vendor_bin_dir
+  rescue LoadError
+    ENV["PATH"] = [vendor_bin_dir, ENV["PATH"]].join(File::PATH_SEPARATOR)
+  end
 end


### PR DESCRIPTION
Hello,

Today I wanted to try SciRuby/iruby and the Jupyter-notebook integration using my Ruby 2.4.2 interpreter from https://rubyinstaller.org/.
The installation went smoothly up to the point where I reached the following error:
```
WARNING:root:kernel 25eddbbb-63f6-465e-8c88-29bdc5ee0263 restarted

WARNING: ::CZMQ::FFI is not available without libczmq.

You should install cztop, rbczmq or ffi_rzmq before running iruby notebook. See README.
...
```

But I just installed cztop!

Verifying this on the command-line:
```
$ gem list cz

*** LOCAL GEMS ***

czmq-ffi-gen (0.13.0 x64-mingw32)
cztop (0.11.4)

$ ruby -rcztop -e true

WARNING: ::CZMQ::FFI is not available without libczmq.

D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/ffi-1.9.18-x64-mingw32/lib/ffi/library.rb:147:in `block in ffi_lib': Could not open library '/usr/local/lib (LoadError): The specified module could not be found.
.
Could not open library '/opt/local/lib/libzmq.dll': The specified module could not be found.
.
Could not open library '/usr/lib64/libzmq.dll': The specified module could not be found.
.
Could not open library 'libzmq': The specified module could not be found.
.
Could not open library 'libzmq.dll': The specified module could not be found.
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/ffi-1.9.18-x64-mingw32/lib/ffi/library.rb:100:in `map'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/ffi-1.9.18-x64-mingw32/lib/ffi/library.rb:100:in `ffi_lib'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen/libzmq.rb:11:in `<module:LibZMQ>'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen/libzmq.rb:3:in `<top (required)>'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen/versions.rb:2:in `require_relative'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen/versions.rb:2:in `<top (required)>'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen.rb:3:in `require_relative'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/czmq-ffi-gen-0.13.0-x64-mingw32/lib/czmq-ffi-gen.rb:3:in `<top (required)>'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/gems/2.4.0/gems/cztop-0.11.4/lib/cztop.rb:1:in `<top (required)>'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `require'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
        from D:/Workspace/install/windows64/ruby-2.4/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
```

This reminded me of a problem I've already seen in one of my own packages when trying to load external libraries with a Ruby version built using the new oneclick/rubyinstaller2 project. You now need to use a specific API for explicitly adding directories from where to load additional DLLs, as explained in the commit message.

With this change I was able to load `cztop` without problems and the Jupyter notebook now works with a Ruby 2.4.2 kernel! (very nice stuff, btw).

![jupyter-iruby-cztop](https://user-images.githubusercontent.com/153279/33132878-3607f2e4-cf9b-11e7-95c2-6f90785cf504.png)

